### PR TITLE
Fix: AI modal appearing on application startup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2299,41 +2299,6 @@
         //     lucide.createIcons();
         // }); // This is commented out as Vue's mounted/updated hooks handle icons.
     </script>
-    <!-- AI Assistant Modal (Vue specific) -->
-    <div v-if="showAiModal" class="fixed inset-0 bg-black/30 backdrop-blur-sm overflow-y-auto h-full w-full flex items-center justify-center z-50 p-4">
-        <div class="relative mx-auto border border-gray-300 w-full max-w-3xl shadow-2xl rounded-xl bg-white modal-content">
-            <div class="flex justify-between items-center p-6 border-b border-gray-200">
-                <h3 class="text-xl font-semibold text-gray-900">AI Assistant <span v-if="aiModalContextInfo" class="text-base font-normal text-gray-600">- {{ aiModalContextInfo }}</span></h3>
-                <button @click="closeAiModal" class="text-gray-400 hover:text-gray-600 transition-colors">
-                    <i data-lucide="x" class="w-6 h-6"></i>
-                </button>
-            </div>
-            <div class="p-6">
-                <div class="mb-4">
-                    <label for="aiModalFullPromptTextarea" class="block text-sm font-medium text-gray-700 mb-1">Full Prompt (for copy-pasting):</label>
-                    <textarea id="aiModalFullPromptTextarea" v-model="aiModalFullPrompt" rows="15" class="w-full p-2 border border-gray-300 rounded-md shadow-sm text-xs"></textarea>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <div>
-                        <h4 class="text-md font-semibold mb-1 text-gray-700">Application JSON (Snapshot):</h4>
-                        <pre v-text="aiModalAppJsonString" class="bg-gray-50 p-2.5 rounded-md overflow-x-auto max-h-60 border border-gray-200 text-xs"></pre>
-                    </div>
-                    <div>
-                        <h4 class="text-md font-semibold mb-1 text-gray-700">Contextual Questions:</h4>
-                        <div v-html="aiModalContextQuestionsHtml" class="bg-gray-50 p-2.5 rounded-md max-h-60 overflow-y-auto border border-gray-200 text-xs prose prose-sm"></div>
-                    </div>
-                </div>
-                <div class="flex flex-col sm:flex-row justify-around items-center pt-4 border-t mt-4 space-y-2 sm:space-y-0 sm:space-x-3">
-                    <a href="https://chat.openai.com" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">ChatGPT</a>
-                    <a href="https://gemini.google.com" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">Gemini</a>
-                    <a href="https://claude.ai" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">Claude</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    </div> <!-- End of #app -->
-
     <!-- Modal HTML was already added in a previous step by a similar subtask, will verify its presence and structure -->
     <!-- Ensuring Lucide JS is loaded before the custom script -->
     <!-- The old DOMContentLoaded script will be removed. -->


### PR DESCRIPTION
I removed duplicated AI Assistant modal HTML and an extraneous closing div tag from public/index.html. This ensures the modal's visibility is solely controlled by the `showAiModal` Vue data property, which is correctly initialized to `false`.

The modal should no longer appear on initial load but will remain functional when triggered by AI button clicks.