### PR TITLE
Add ItemBadge component and integrate in lists and modal

### DIFF
--- a/public/js/components/ItemBadge.js
+++ b/public/js/components/ItemBadge.js
@@ -1,0 +1,49 @@
+export const ItemBadge = {
+    props: {
+        name: {
+            type: String,
+            required: true
+        },
+        icon: {
+            type: String,
+            default: 'hash'
+        },
+        item: {
+            type: Object,
+            default: null
+        },
+        type: {
+            type: String,
+            default: ''
+        }
+    },
+    methods: {
+        handleClick() {
+            if (this.item && this.type) {
+                this.$emit('view-item-requested', { item: this.item, type: this.type });
+            } else {
+                this.$emit('view-item-requested');
+            }
+        }
+    },
+    template: `
+        <span @click="handleClick" class="inline-flex items-center space-x-1 bg-gray-100 hover:bg-gray-200 text-gray-700 px-2 py-1 rounded-full text-xs cursor-pointer">
+            <i :data-lucide="icon" class="w-3 h-3"></i>
+            <span>{{ name }}</span>
+        </span>
+    `,
+    mounted() {
+        this.$nextTick(() => {
+            if (typeof lucide !== 'undefined') {
+                lucide.createIcons();
+            }
+        });
+    },
+    updated() {
+        this.$nextTick(() => {
+            if (typeof lucide !== 'undefined') {
+                lucide.createIcons();
+            }
+        });
+    }
+};

--- a/public/js/components/OpportunityListItem.js
+++ b/public/js/components/OpportunityListItem.js
@@ -15,7 +15,14 @@ export const OpportunityListItem = {
             <div class="flex flex-col md:flex-row justify-between items-start md:items-center p-4">
                 <div class="flex-1 mb-3 md:mb-0 md:mr-4 min-w-0">
                     <h3 class="text-lg font-semibold text-blue-600 truncate" :title="opportunity.opportunityName">{{ opportunity.opportunityName || 'N/A' }}</h3>
-                    <p class="text-xs text-gray-500">ID: {{ opportunity.opportunityId }}</p>
+                    <item-badge
+                        class="mt-1"
+                        :name="opportunity.opportunityId"
+                        icon="hash"
+                        :item="opportunity"
+                        type="opportunity"
+                        @view-item-requested="$emit('view-item-requested', $event)"
+                    ></item-badge>
                 </div>
                 <div class="w-full md:w-1/4 text-sm text-gray-700 mb-2 md:mb-0 md:text-center truncate" :title="getPersonNameFn(opportunity.opportunityProposerId)">
                     {{ getPersonNameFn(opportunity.opportunityProposerId) }}

--- a/public/js/components/ViewItemModal.js
+++ b/public/js/components/ViewItemModal.js
@@ -40,15 +40,29 @@ export const ViewItemModal = {
                                     <span v-else class="text-gray-500 italic">No items defined</span>
                                 </div>
                                 <div v-else-if="field.relationshipType === 'person' && getPersonNameFn">
-                                     <span v-if="itemData[field.key]" @click="handleViewItem(itemData[field.key], 'person')" class="text-blue-600 hover:underline cursor-pointer">
-                                        {{ getPersonNameFn(itemData[field.key]) }} ({{ itemData[field.key] }})
-                                    </span>
+                                     <template v-if="itemData[field.key]">
+                                        <span class="mr-2">{{ getPersonNameFn(itemData[field.key]) }}</span>
+                                        <item-badge
+                                            :name="itemData[field.key]"
+                                            icon="hash"
+                                            :item="{ personId: itemData[field.key], personName: getPersonNameFn(itemData[field.key]) }"
+                                            type="person"
+                                            @view-item-requested="handleViewItem($event.item, $event.type)"
+                                        ></item-badge>
+                                     </template>
                                     <span v-else class="text-gray-500 italic">Not specified</span>
                                 </div>
                                 <div v-else-if="field.relationshipType === 'opportunity' && getOpportunityNameFn">
-                                     <span v-if="itemData[field.key]" @click="handleViewItem(itemData[field.key], 'opportunity')" class="text-blue-600 hover:underline cursor-pointer">
-                                        {{ getOpportunityNameFn(itemData[field.key]) }} ({{ itemData[field.key] }})
-                                    </span>
+                                     <template v-if="itemData[field.key]">
+                                        <span class="mr-2">{{ getOpportunityNameFn(itemData[field.key]) }}</span>
+                                        <item-badge
+                                            :name="itemData[field.key]"
+                                            icon="hash"
+                                            :item="{ opportunityId: itemData[field.key], opportunityName: getOpportunityNameFn(itemData[field.key]) }"
+                                            type="opportunity"
+                                            @view-item-requested="handleViewItem($event.item, $event.type)"
+                                        ></item-badge>
+                                     </template>
                                     <span v-else class="text-gray-500 italic">Not specified</span>
                                 </div>
                                 <span v-else>{{ itemData[field.key] || 'Not specified' }}</span>


### PR DESCRIPTION
## Summary
- add ItemBadge component for displaying IDs as clickable badges
- register the new component globally
- allow `viewItem` to accept item IDs
- use ItemBadge in OpportunityListItem
- show related IDs in ViewItemModal using ItemBadge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406bac376c8320a53c15f703a615d1