### PR TITLE
Clamp card descriptions

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -227,7 +227,15 @@
     text-overflow: ellipsis; /* Add ellipsis for truncated text */
     white-space: nowrap; /* Prevent text from wrapping */
 }
- .view-item-modal-content .related-item-type {
+.view-item-modal-content .related-item-type {
     font-size: 0.75rem; /* text-xs */
     color: #6b7280; /* gray-500 */
- }
+}
+
+/* Utility class replicating Tailwind's line-clamp-2 */
+.line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}

--- a/public/js/components/FieldRenderer.js
+++ b/public/js/components/FieldRenderer.js
@@ -3,7 +3,8 @@ export const FieldRenderer = {
     fieldKey: { type: String, required: true },
     value: { default: '' },
     fieldMeta: { type: Object, default: () => ({}) },
-    editable: { type: Boolean, default: false }
+    editable: { type: Boolean, default: false },
+    displayClass: { type: String, default: '' }
   },
   emits: ['update'],
   data() {
@@ -41,7 +42,7 @@ export const FieldRenderer = {
       <template v-else>
         <span class="inline-flex items-center space-x-1" :title="fieldMeta.tooltip">
           <i v-if="fieldMeta.icon" :data-lucide="fieldMeta.icon" class="w-3 h-3"></i>
-          <span>{{ displayValue }}</span>
+          <span :class="displayClass">{{ displayValue }}</span>
         </span>
       </template>
     </div>

--- a/public/js/components/InitiativeListItem.js
+++ b/public/js/components/InitiativeListItem.js
@@ -14,6 +14,7 @@ export const InitiativeListItem = {
                     <p class="text-sm text-gray-500 mb-1">Type: <span class="font-medium text-gray-700">{{ initiative.initiativeType }}</span></p>
                     <p class="text-sm text-gray-500 mb-1">Manager: <span class="font-medium text-gray-700 truncate" :title="getPersonNameFn(initiative.initiativeManagerId)">{{ getPersonNameFn(initiative.initiativeManagerId) }}</span></p>
                     <p class="text-sm text-gray-500">Budget: <span class="font-medium text-gray-700">€{{ $appUtils.formatNumber(initiative.initiativeBudget) }}</span></p>
+                    <p v-if="initiative.initiativeObjective" class="text-sm text-gray-600 mt-2 line-clamp-2">{{ initiative.initiativeObjective }}</p>
                 </div>
                 <div class="flex flex-col md:flex-row md:items-center space-y-2 md:space-y-0 md:space-x-2 flex-shrink-0 hover-actions">
                     <button @click="$emit('view-item-requested', { item: initiative, type: 'initiative' })" class="w-full md:w-auto flex items-center justify-center space-x-2 bg-blue-100 hover:bg-blue-200 text-blue-700 px-4 py-2 rounded-lg text-sm font-medium transition-colors" title="View Initiative">

--- a/public/js/components/OpportunityListItem.js
+++ b/public/js/components/OpportunityListItem.js
@@ -53,7 +53,7 @@ export const OpportunityListItem = {
                 </div>
             </div>
             <div class="px-4 pb-3 pt-2 border-t border-gray-100" v-if="opportunity.opportunityDescription">
-                 <p class="text-sm text-gray-600 leading-relaxed">{{ opportunity.opportunityDescription.length > 150 ? opportunity.opportunityDescription.substring(0, 150) + '...' : opportunity.opportunityDescription }}</p>
+                 <p class="text-sm text-gray-600 leading-relaxed line-clamp-2">{{ opportunity.opportunityDescription }}</p>
             </div>
         </div>
     `,

--- a/public/js/components/PersonCard.js
+++ b/public/js/components/PersonCard.js
@@ -31,6 +31,7 @@ export const PersonCard = {
                         field-key="personDescription"
                         :value="person.personDescription"
                         :field-meta="descriptionMeta"
+                        display-class="line-clamp-2"
                     ></field-renderer>
                     <div v-if="person.personUrl" class="mb-4">
                         <a :href="person.personUrl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center space-x-1 text-blue-600 hover:text-blue-700 text-sm">


### PR DESCRIPTION
## Summary
- allow custom classes on `FieldRenderer`
- truncate card descriptions with the new `line-clamp-2` utility
- display initiative objective text in list items
- add CSS to mimic Tailwind's line-clamp utility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407c6213348320b766b783e6a0db13