### PR TITLE
Enhance item modal and table view

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24,6 +24,7 @@ import { InitiativesView } from './components/InitiativesView.js';
 import { TableView } from './components/TableView.js';
 import { ItemBadge } from './components/ItemBadge.js';
 import { FieldRenderer } from './components/FieldRenderer.js';
+import { SearchSelect } from './components/SearchSelect.js';
 import { getFieldMeta } from './fieldMeta.js';
 
 const { createApp } = Vue; // Vue import
@@ -376,6 +377,8 @@ const app = createApp({
                 format: prop.format,
                 relationshipType: prop.relationshipType,
             }));
+            this.itemModalFormFields = this.generateFormFields(schemaDefinition);
+            this.itemModalFormData = this.prepareFormData(item, this.itemModalFormFields);
             this.findRelatedItems(item, type);
             this.itemModalActiveTab = 'view'; this.showItemModal = true;
         },
@@ -507,5 +510,6 @@ app.component('initiatives-view', InitiativesView);
 app.component('table-view', TableView);
 app.component('item-badge', ItemBadge);
 app.component('field-renderer', FieldRenderer);
+app.component('search-select', SearchSelect);
 
 app.mount('#app');

--- a/public/js/components/FieldRenderer.js
+++ b/public/js/components/FieldRenderer.js
@@ -1,3 +1,5 @@
+import { ItemBadge } from './ItemBadge.js';
+
 export const FieldRenderer = {
   props: {
     fieldKey: { type: String, required: true },
@@ -6,7 +8,8 @@ export const FieldRenderer = {
     editable: { type: Boolean, default: false },
     displayClass: { type: String, default: '' }
   },
-  emits: ['update'],
+  components: { ItemBadge },
+  emits: ['update', 'view-item-requested'],
   data() {
     return { internalValue: this.value };
   },
@@ -36,11 +39,27 @@ export const FieldRenderer = {
         <select v-if="fieldMeta.enum" v-model="internalValue" @change="emitUpdate" class="form-select w-full">
           <option v-for="option in fieldMeta.enum" :key="option" :value="option">{{ option }}</option>
         </select>
-        <textarea v-else-if="fieldMeta.format === 'textarea'" v-model="internalValue" @input="emitUpdate" rows="3" class="form-input form-textarea w-full"></textarea>
-        <input v-else :type="inputType" v-model="internalValue" @input="emitUpdate" class="form-input w-full"/>
+        <textarea v-else-if="fieldMeta.format === 'textarea'" v-model="internalValue" @keydown.enter.prevent="emitUpdate" @blur="emitUpdate" rows="3" class="form-input form-textarea w-full"></textarea>
+        <input v-else :type="inputType" v-model="internalValue" @keydown.enter.prevent="emitUpdate" @blur="emitUpdate" class="form-input w-full"/>
       </template>
       <template v-else>
-        <span class="inline-flex items-center space-x-1" :title="fieldMeta.tooltip">
+        <item-badge
+          v-if="fieldMeta.relationshipType === 'person'"
+          :name="$root.getPersonName(value)"
+          icon="user"
+          :item="$root.getPerson(value)"
+          type="person"
+          @view-item-requested="$emit('view-item-requested', $event)"
+        ></item-badge>
+        <item-badge
+          v-else-if="fieldMeta.relationshipType === 'opportunity'"
+          :name="$root.getOpportunityName(value)"
+          icon="lightbulb"
+          :item="$root.getOpportunity(value)"
+          type="opportunity"
+          @view-item-requested="$emit('view-item-requested', $event)"
+        ></item-badge>
+        <span v-else class="inline-flex items-center space-x-1" :title="fieldMeta.tooltip">
           <i v-if="fieldMeta.icon" :data-lucide="fieldMeta.icon" class="w-3 h-3"></i>
           <span :class="displayClass">{{ displayValue }}</span>
         </span>

--- a/public/js/components/InitiativeListItem.js
+++ b/public/js/components/InitiativeListItem.js
@@ -12,7 +12,15 @@ export const InitiativeListItem = {
                         </span>
                     </div>
                     <p class="text-sm text-gray-500 mb-1">Type: <span class="font-medium text-gray-700">{{ initiative.initiativeType }}</span></p>
-                    <p class="text-sm text-gray-500 mb-1">Manager: <span class="font-medium text-gray-700 truncate" :title="getPersonNameFn(initiative.initiativeManagerId)">{{ getPersonNameFn(initiative.initiativeManagerId) }}</span></p>
+                    <p class="text-sm text-gray-500 mb-1">Manager:
+                        <item-badge
+                            :name="getPersonNameFn(initiative.initiativeManagerId)"
+                            icon="user"
+                            :item="{ personId: initiative.initiativeManagerId, personName: getPersonNameFn(initiative.initiativeManagerId) }"
+                            type="person"
+                            @view-item-requested="$emit('view-item-requested', $event)"
+                        ></item-badge>
+                    </p>
                     <p class="text-sm text-gray-500">Budget: <span class="font-medium text-gray-700">€{{ $appUtils.formatNumber(initiative.initiativeBudget) }}</span></p>
                     <p v-if="initiative.initiativeObjective" class="text-sm text-gray-600 mt-2 line-clamp-2">{{ initiative.initiativeObjective }}</p>
                 </div>

--- a/public/js/components/InitiativesView.js
+++ b/public/js/components/InitiativesView.js
@@ -1,3 +1,6 @@
+import { TableView } from './TableView.js';
+import { APP_SCHEMA } from '../appSchema.js';
+
 export const InitiativesView = {
     props: {
         initiatives: Array,
@@ -9,7 +12,11 @@ export const InitiativesView = {
             default: 'table'
         }
     },
+    components: { TableView },
     emits: ['add-initiative-requested', 'open-ai-modal-requested', 'sort-requested', 'view-item-requested', 'edit-item-requested', 'delete-item-requested'],
+    computed: {
+        tableFields() { return this.$root.generateFormFields(APP_SCHEMA.definitions.initiative); }
+    },
     template: `
         <section class="space-y-6">
             <div class="flex justify-between items-center">
@@ -40,34 +47,10 @@ export const InitiativesView = {
             </div>
 
             <div v-else>
-                <div v-if="viewMode === 'table'" class="space-y-4">
-                    <div class="flex justify-between items-center text-xs text-gray-500 font-medium px-6 py-2 border-b bg-gray-50 rounded-t-lg">
-                        <div class="flex-1 cursor-pointer hover:text-gray-800" @click="$emit('sort-requested', 'initiativeName')">
-                            Name
-                            <i v-if="currentSortField === 'initiativeName'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                        </div>
-                    <div class="w-1/4 cursor-pointer hover:text-gray-800 text-center" @click="$emit('sort-requested', 'initiativePhase')">
-                        Phase
-                        <i v-if="currentSortField === 'initiativePhase'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                    </div>
-                    <div class="w-1/6 cursor-pointer hover:text-gray-800 text-center" @click="$emit('sort-requested', 'initiativeType')">
-                        Type
-                        <i v-if="currentSortField === 'initiativeType'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                    </div>
-                    <div class="w-1/6 text-right">Actions</div>
+                <div v-if="viewMode === 'table'">
+                    <table-view :items="initiatives" :fields="tableFields" app-data-section="initiatives" @view-item-requested="$emit('view-item-requested', $event)"></table-view>
                 </div>
-                <initiative-list-item
-                    v-for="init in initiatives"
-                    :key="init.initiativeId"
-                    :initiative="init"
-                    :get-person-name-fn="getPersonNameFn"
-                    @view-item-requested="$emit('view-item-requested', $event)"
-                    @edit-item-requested="$emit('edit-item-requested', $event)"
-                    @open-ai-modal-requested="$emit('open-ai-modal-requested', $event)"
-                    @delete-item-requested="$emit('delete-item-requested', $event)">
-                </initiative-list-item>
-                </div>
-                <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div v-else class="space-y-4">
                     <initiative-list-item
                         v-for="init in initiatives"
                         :key="init.initiativeId"

--- a/public/js/components/ItemModal.js
+++ b/public/js/components/ItemModal.js
@@ -1,4 +1,5 @@
 import { FieldRenderer } from './FieldRenderer.js';
+import { SearchSelect } from './SearchSelect.js';
 
 export const ItemModal = {
     props: {
@@ -18,7 +19,7 @@ export const ItemModal = {
         getOpportunityNameFn: Function,
         viewItemFn: Function
     },
-    components: { FieldRenderer },
+    components: { FieldRenderer, SearchSelect },
     data() {
         return {
             currentFormData: {},
@@ -39,7 +40,16 @@ export const ItemModal = {
         }
     },
     methods: {
-        switchTab(tab) { this.internalTab = tab; this.$emit('update:activeTab', tab); },
+        switchTab(tab) {
+            this.internalTab = tab;
+            this.$emit('update:activeTab', tab);
+            if (tab === 'edit') {
+                this.$nextTick(() => {
+                    const first = this.$el.querySelector('input, textarea, select');
+                    if (first) first.focus();
+                });
+            }
+        },
         closeModal() { this.$emit('close-modal-requested'); },
         saveForm() { this.$emit('save-form-requested', JSON.parse(JSON.stringify(this.currentFormData))); },
         saveAndDownload() { this.$emit('save-and-download-requested', JSON.parse(JSON.stringify(this.currentFormData))); },
@@ -56,7 +66,14 @@ export const ItemModal = {
                 this.currentFormData[fieldKey].splice(index, 1);
             }
         },
-        handleViewItem(item, type) { if (this.viewItemFn) { this.viewItemFn(item, type); } }
+        handleViewItem(item, type) { if (this.viewItemFn) { this.viewItemFn(item, type); } },
+        handleKeydown(event) { if (event.key === 'Escape') this.closeModal(); }
+    },
+    mounted() {
+        document.addEventListener('keydown', this.handleKeydown);
+    },
+    unmounted() {
+        document.removeEventListener('keydown', this.handleKeydown);
     },
     template: `
         <div v-if="show" class="fixed inset-0 bg-black/30 backdrop-blur-sm overflow-y-auto h-full w-full flex items-center justify-center z-50 p-4">
@@ -74,7 +91,13 @@ export const ItemModal = {
                 <div v-if="internalTab==='view'" class="view-item-modal-content">
                     <div v-if="itemData">
                         <div v-for="field in itemFields" :key="field.key" class="field-display">
-                            <div class="field-label">{{ field.title }}</div>
+                            <div class="field-label flex items-center">
+                                <span class="tooltip-container">
+                                    <i class="tooltip-icon">?</i>
+                                    <span class="tooltip-text">{{ field.description }}</span>
+                                </span>
+                                {{ field.title }}
+                            </div>
                             <div class="field-value">
                                 <div v-if="Array.isArray(itemData[field.key])">
                                     <ul v-if="itemData[field.key].length > 0" class="list-disc list-inside">
@@ -117,11 +140,16 @@ export const ItemModal = {
                         </div>
                         <div v-if="relatedItemsData && relatedItemsData.length > 0" class="related-items-section">
                             <h4 class="text-lg font-semibold text-gray-900 mb-4">Related Items</h4>
-                            <div class="related-items-grid">
-                                <div v-for="related in relatedItemsData" :key="related.id" @click="handleViewItem(related.item, related.type)" class="related-item-card">
-                                    <p class="related-item-title">{{ related.name }}</p>
-                                    <p class="related-item-type">{{ related.type.charAt(0).toUpperCase() + related.type.slice(1) }}</p>
-                                </div>
+                            <div class="related-items-list flex flex-wrap gap-2">
+                                <item-badge
+                                    v-for="related in relatedItemsData"
+                                    :key="related.id"
+                                    :name="related.name"
+                                    icon="link"
+                                    :item="related.item"
+                                    :type="related.type"
+                                    @view-item-requested="handleViewItem($event.item, $event.type)"
+                                ></item-badge>
                             </div>
                         </div>
                     </div>
@@ -167,24 +195,18 @@ export const ItemModal = {
                                     <option value="">Select {{ field.title }}</option>
                                     <option v-for="option in field.enum" :key="option" :value="option">{{ option }}</option>
                                 </select>
-                                <select v-else-if="field.relationshipType === 'person'"
-                                        :id="field.key"
-                                        v-model="currentFormData[field.key]"
-                                        class="form-select">
-                                    <option value="">Select Person</option>
-                                    <option v-for="person in peopleList" :key="person.personId" :value="person.personId">
-                                        {{ person.personName }} ({{ person.personId }})
-                                    </option>
-                                </select>
-                                <select v-else-if="field.relationshipType === 'opportunity'"
-                                        :id="field.key"
-                                        v-model="currentFormData[field.key]"
-                                        class="form-select">
-                                    <option value="">Select Opportunity</option>
-                                    <option v-for="opp in opportunitiesList" :key="opp.opportunityId" :value="opp.opportunityId">
-                                        {{ opp.opportunityName }} ({{ opp.opportunityId }})
-                                    </option>
-                                </select>
+                                <search-select v-else-if="field.relationshipType === 'person'"
+                                        :model-value="currentFormData[field.key]"
+                                        @update:modelValue="val => currentFormData[field.key] = val"
+                                        :options="peopleList.map(p => ({ value: p.personId, label: p.personName }))"
+                                        placeholder="Select Person">
+                                </search-select>
+                                <search-select v-else-if="field.relationshipType === 'opportunity'"
+                                        :model-value="currentFormData[field.key]"
+                                        @update:modelValue="val => currentFormData[field.key] = val"
+                                        :options="opportunitiesList.map(o => ({ value: o.opportunityId, label: o.opportunityName }))"
+                                        placeholder="Select Opportunity">
+                                </search-select>
                                 <textarea v-else-if="field.type === 'array' && !field.isSimpleStringArray"
                                           :id="field.key"
                                           v-model="currentFormData[field.key + '_json']"

--- a/public/js/components/OpportunitiesView.js
+++ b/public/js/components/OpportunitiesView.js
@@ -1,3 +1,6 @@
+import { TableView } from './TableView.js';
+import { APP_SCHEMA } from '../appSchema.js';
+
 export const OpportunitiesView = {
     props: {
         opportunities: { type: Array, default: () => [] },
@@ -15,6 +18,7 @@ export const OpportunitiesView = {
             default: 'table'
         }
     },
+    components: { TableView },
     data() {
         return {
             filterName: this.initialFilterName,
@@ -29,7 +33,8 @@ export const OpportunitiesView = {
                 return this.programDefaultOpportunityStatuses;
             }
             return this.appSchemaOpportunityStatuses;
-        }
+        },
+        tableFields() { return this.$root.generateFormFields(APP_SCHEMA.definitions.opportunity); }
     },
     watch: {
         filterName(newValue) { this.$emit('filters-changed', { name: newValue, proposerId: this.filterProposerId, status: this.filterStatus }); },
@@ -90,37 +95,10 @@ export const OpportunitiesView = {
             </div>
 
             <div v-else>
-                <div v-if="viewMode === 'table'" class="space-y-3">
-                    <div class="flex justify-between items-center text-xs text-gray-500 font-medium px-3 py-2 border-b bg-gray-50 rounded-t-lg">
-                        <div class="flex-1 cursor-pointer hover:text-gray-800" @click="handleSortRequested('opportunityName')">
-                            Name
-                            <i v-if="currentSortField === 'opportunityName'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                        </div>
-                    <div class="w-1/4 cursor-pointer hover:text-gray-800 text-center" @click="handleSortRequested('opportunityProposerId')">
-                        Proposer
-                         <i v-if="currentSortField === 'opportunityProposerId'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                    </div>
-                     <div class="w-1/6 cursor-pointer hover:text-gray-800 text-center" @click="handleSortRequested('opportunityStatus')">
-                        Status
-                        <i v-if="currentSortField === 'opportunityStatus'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-az' : 'arrow-down-za'" class="sort-icon"></i>
-                    </div>
-                    <div class="w-1/6 cursor-pointer hover:text-gray-800 text-center" @click="handleSortRequested('opportunityPriority')">
-                        Priority
-                        <i v-if="currentSortField === 'opportunityPriority'" :data-lucide="currentSortOrder === 'asc' ? 'arrow-up-0-9' : 'arrow-down-9-0'" class="sort-icon"></i>
-                    </div>
-                    <div class="w-1/6 text-right">Actions</div>
+                <div v-if="viewMode === 'table'">
+                    <table-view :items="opportunities" :fields="tableFields" app-data-section="opportunities" @view-item-requested="$emit('view-item-requested', $event)"></table-view>
                 </div>
-
-                <opportunity-list-item v-for="opp in opportunities" :key="opp.opportunityId"
-                    :opportunity="opp"
-                    :get-person-name-fn="getPersonNameFn"
-                    @view-item-requested="$emit('view-item-requested', $event)"
-                    @edit-item-requested="$emit('edit-item-requested', $event)"
-                    @open-ai-modal-requested="$emit('open-ai-modal-requested', $event)"
-                    @delete-item-requested="$emit('delete-item-requested', $event)">
-                </opportunity-list-item>
-                </div>
-                <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div v-else class="space-y-4">
                     <opportunity-list-item v-for="opp in opportunities" :key="opp.opportunityId"
                         :opportunity="opp"
                         :get-person-name-fn="getPersonNameFn"

--- a/public/js/components/OpportunityListItem.js
+++ b/public/js/components/OpportunityListItem.js
@@ -24,8 +24,14 @@ export const OpportunityListItem = {
                         @view-item-requested="$emit('view-item-requested', $event)"
                     ></item-badge>
                 </div>
-                <div class="w-full md:w-1/4 text-sm text-gray-700 mb-2 md:mb-0 md:text-center truncate" :title="getPersonNameFn(opportunity.opportunityProposerId)">
-                    {{ getPersonNameFn(opportunity.opportunityProposerId) }}
+                <div class="w-full md:w-1/4 text-sm text-gray-700 mb-2 md:mb-0 md:text-center truncate">
+                    <item-badge
+                        :name="getPersonNameFn(opportunity.opportunityProposerId)"
+                        icon="user"
+                        :item="{ personId: opportunity.opportunityProposerId, personName: getPersonNameFn(opportunity.opportunityProposerId) }"
+                        type="person"
+                        @view-item-requested="$emit('view-item-requested', $event)"
+                    ></item-badge>
                 </div>
                  <div class="w-full md:w-1/6 flex justify-start md:justify-center mb-3 md:mb-0">
                     <span :class="$appUtils.getPhaseClass(opportunity.opportunityStatus)" class="status-badge">

--- a/public/js/components/PeopleView.js
+++ b/public/js/components/PeopleView.js
@@ -1,3 +1,6 @@
+import { TableView } from './TableView.js';
+import { APP_SCHEMA } from '../appSchema.js';
+
 export const PeopleView = {
     props: {
         people: {
@@ -13,7 +16,10 @@ export const PeopleView = {
             default: 'grid'
         }
     },
-    // Components are registered globally in app.js, so no local 'components' registration for PersonCard needed here.
+    components: { TableView },
+    computed: {
+        tableFields() { return this.$root.generateFormFields(APP_SCHEMA.definitions.person); }
+    },
     template: `
         <section class="space-y-6">
             <div class="flex justify-between items-center">
@@ -44,7 +50,7 @@ export const PeopleView = {
             </div>
 
             <div v-else>
-                <div v-if="viewMode === 'grid'" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div v-if="viewMode === 'grid'" class="space-y-4">
                     <person-card
                         v-for="person in people"
                         :key="person.personId"
@@ -56,32 +62,7 @@ export const PeopleView = {
                         @delete-item-requested="$emit('delete-item-requested', $event)">
                     </person-card>
                 </div>
-                <table v-else class="min-w-full divide-y divide-gray-200">
-                    <thead class="bg-gray-50 text-xs text-gray-500">
-                        <tr>
-                            <th class="px-4 py-2 text-left font-medium">Name</th>
-                            <th class="px-4 py-2 text-left font-medium">Description</th>
-                            <th class="px-4 py-2 text-right font-medium">Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody class="divide-y divide-gray-200">
-                        <tr v-for="person in people" :key="person.personId" class="bg-white">
-                            <td class="px-4 py-2">
-                                <div class="flex items-center space-x-2">
-                                    <img :src="getPersonAvatarFn(person.personId)" :alt="person.personName" class="w-8 h-8 rounded-full" />
-                                    <span class="font-medium">{{ person.personName || 'N/A' }}</span>
-                                </div>
-                            </td>
-                            <td class="px-4 py-2 text-sm text-gray-700">{{ person.personDescription || 'No description' }}</td>
-                            <td class="px-4 py-2 text-right space-x-2">
-                                <button @click="$emit('view-item-requested', { item: person, type: 'person' })" class="p-1.5 bg-blue-100 hover:bg-blue-200 text-blue-700 rounded-md" title="View Person"><i data-lucide="eye" class="w-4 h-4"></i></button>
-                                <button @click="$emit('edit-item-requested', person)" class="p-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-md" title="Edit Person"><i data-lucide="edit" class="w-4 h-4"></i></button>
-                                <button @click="$emit('open-ai-modal-requested', { contextType: 'personItem', item: person })" class="p-1.5 bg-purple-100 hover:bg-purple-200 text-purple-700 rounded-md" :title="'AI Assistant for ' + person.personName"><i data-lucide="bot" class="w-4 h-4"></i></button>
-                                <button @click="$emit('delete-item-requested', person.personId)" class="p-1.5 bg-red-100 hover:bg-red-200 text-red-600 rounded-md" title="Delete Person"><i data-lucide="trash-2" class="w-4 h-4"></i></button>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <table-view v-else :items="people" :fields="tableFields" app-data-section="people" @view-item-requested="$emit('view-item-requested', $event)"></table-view>
             </div>
         </section>
     `,

--- a/public/js/components/SearchSelect.js
+++ b/public/js/components/SearchSelect.js
@@ -1,0 +1,44 @@
+export const SearchSelect = {
+  props: {
+    modelValue: String,
+    options: { type: Array, default: () => [] },
+    placeholder: { type: String, default: '' }
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return { search: '', showList: false };
+  },
+  computed: {
+    selectedLabel() {
+      const opt = this.options.find(o => o.value === this.modelValue);
+      return opt ? opt.label : '';
+    },
+    filtered() {
+      if (!this.search) return this.options;
+      return this.options.filter(o => o.label.toLowerCase().includes(this.search.toLowerCase()));
+    }
+  },
+  watch: {
+    modelValue() { this.search = this.selectedLabel; }
+  },
+  mounted() {
+    this.search = this.selectedLabel;
+  },
+  methods: {
+    choose(option) {
+      this.$emit('update:modelValue', option.value);
+      this.search = option.label;
+      this.showList = false;
+    }
+  },
+  template: `
+    <div class="relative">
+      <input type="text" class="form-input w-full" :placeholder="placeholder"
+             v-model="search" @focus="showList = true" @input="showList = true">
+      <ul v-if="showList" class="absolute z-10 bg-white border border-gray-200 mt-1 rounded max-h-40 overflow-y-auto w-full">
+        <li v-for="opt in filtered" :key="opt.value" @mousedown.prevent="choose(opt)"
+            class="px-3 py-1 hover:bg-gray-100 cursor-pointer">{{ opt.label }}</li>
+      </ul>
+    </div>
+  `
+};

--- a/public/js/components/TableView.js
+++ b/public/js/components/TableView.js
@@ -13,7 +13,7 @@ export const TableView = {
         appDataSection: { type: String, default: '' }
     },
     components: { FieldRenderer },
-    emits: ['update-item'],
+    emits: ['update-item', 'view-item-requested'],
     data() {
         return {
             editableItems: [],
@@ -88,6 +88,7 @@ export const TableView = {
                                 :field-meta="field"
                                 editable
                                 @update="val => { row[field.key] = val; emitUpdate(rowIndex); }"
+                                @view-item-requested="$emit('view-item-requested', $event)"
                             ></field-renderer>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
- add SearchSelect for searchable relationship fields
- show relationship fields with ItemBadge and inline editing committed on Enter/blur
- improve ItemModal usability (Escape key closes, info tooltips in view tab)
- fix switching from view to edit tab
- replace manual tables with generic TableView in section views
- display related items as badges
- use ItemBadge in list items for managers and proposers
- register new components globally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684065781c0883209a79903227f2b24a