### PR TITLE
Add titles and descriptions to schema

### DIFF
--- a/public/js/appSchema.js
+++ b/public/js/appSchema.js
@@ -5,10 +5,29 @@ export const APP_SCHEMA = {
   "publishedDate": "2025-06-05",
   "type": "object",
   "properties": {
-    "program": { "$ref": "#/definitions/programConfiguration" },
-    "people": { "type": "array", "items": { "$ref": "#/definitions/person" } },
-    "opportunities": { "type": "array", "items": { "$ref": "#/definitions/opportunity" } },
-    "initiatives": { "type": "array", "items": { "$ref": "#/definitions/iNNitiative" } }
+    "program": {
+      "$ref": "#/definitions/programConfiguration",
+      "title": "Program",
+      "description": "Configuration details for the innovation program"
+    },
+    "people": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/person" },
+      "title": "People",
+      "description": "Participants involved in the program"
+    },
+    "opportunities": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/opportunity" },
+      "title": "Opportunities",
+      "description": "Innovation opportunities tracked in the program"
+    },
+    "initiatives": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/iNNitiative" },
+      "title": "Initiatives",
+      "description": "Innovation initiatives derived from opportunities"
+    }
   },
   "required": ["program", "people", "opportunities", "initiatives"],
   "definitions": {
@@ -16,40 +35,90 @@ export const APP_SCHEMA = {
       "type": "object",
       "title": "Program Configuration",
       "properties": {
-        "programName": { "type": "string" },
-        "programObjectives": { "type": "string", "format": "textarea" },
-        "programScope": { "type": "string", "format": "textarea" },
-        "programIndicators": { "type": "string", "format": "textarea" },
-        "programGovernance": { "type": "string", "format": "textarea" },
-        "programFunding": { "type": "string", "format": "textarea" },
+        "programName": {
+          "type": "string",
+          "title": "Program Name",
+          "description": "Name of the innovation program"
+        },
+        "programObjectives": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Objectives",
+          "description": "Main objectives of the program"
+        },
+        "programScope": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Scope",
+          "description": "Scope or boundaries of the program"
+        },
+        "programIndicators": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Indicators",
+          "description": "Key metrics or indicators to track progress"
+        },
+        "programGovernance": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Governance",
+          "description": "Governance structure for the program"
+        },
+        "programFunding": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Funding",
+          "description": "Funding details for the program"
+        },
         "programStages": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["Idea Definition", "Concept Design", "Prototype Development", "Validation", "Pilot Testing", "Launched", "Scaling", "On Hold", "Cancelled"]
+          "default": ["Idea Definition", "Concept Design", "Prototype Development", "Validation", "Pilot Testing", "Launched", "Scaling", "On Hold", "Cancelled"],
+          "title": "Program Stages",
+          "description": "List of stages in the program"
         },
-        "programReporting": { "type": "string" },
-        "programBusinessDescription": { "type": "string", "format": "textarea" },
+        "programReporting": {
+          "type": "string",
+          "title": "Program Reporting",
+          "description": "Reporting requirements or cadence"
+        },
+        "programBusinessDescription": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Program Business Description",
+          "description": "Business description for the program"
+        },
         "programDefaultOpportunityStatuses": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["Identified", "Under Review", "Prioritized", "Archived"]
+          "default": ["Identified", "Under Review", "Prioritized", "Archived"],
+          "title": "Default Opportunity Statuses",
+          "description": "Default status options for opportunities"
         },
         "programDefaultInitiativeTypes": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["New Product Development", "Process Improvement", "Technology Exploration", "Market Research", "Partnership Development", "Platform Enhancement", "Sustainability Initiative"]
+          "default": ["New Product Development", "Process Improvement", "Technology Exploration", "Market Research", "Partnership Development", "Platform Enhancement", "Sustainability Initiative"],
+          "title": "Default Initiative Types",
+          "description": "Default initiative type options"
         },
         "programLastUpdated": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "title": "Program Last Updated",
+          "description": "Date and time when the program was last updated"
         },
         "programSponsorPersonId": {
           "type": "string",
-          "relationshipType": "person"
+          "relationshipType": "person",
+          "title": "Sponsor Person ID",
+          "description": "Reference to the sponsor of the program"
         },
         "programManagerPersonId": {
           "type": "string",
-          "relationshipType": "person"
+          "relationshipType": "person",
+          "title": "Manager Person ID",
+          "description": "Reference to the program manager"
         }
       },
       "required": [
@@ -67,15 +136,40 @@ export const APP_SCHEMA = {
       "type": "object",
       "title": "Person",
       "properties": {
-        "personId": { "type": "string" },
-        "personName": { "type": "string" },
-        "personDescription": { "type": "string", "format": "textarea" },
+        "personId": {
+          "type": "string",
+          "title": "Person ID",
+          "description": "Unique identifier for the person"
+        },
+        "personName": {
+          "type": "string",
+          "title": "Person Name",
+          "description": "Full name of the person"
+        },
+        "personDescription": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Person Description",
+          "description": "Brief biography or notes about the person"
+        },
         "personRole": {
           "type": "string",
-          "enum": ["Innovation Manager", "Innovation Sponsor", "Team Member", "Collaborator", "Observer"]
+          "enum": ["Innovation Manager", "Innovation Sponsor", "Team Member", "Collaborator", "Observer"],
+          "title": "Person Role",
+          "description": "Role of the person in the innovation program"
         },
-        "personUrl": { "type": "string", "format": "uri" },
-        "personImageUrl": { "type": "string", "format": "uri" }
+        "personUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Person URL",
+          "description": "External link to more information about the person"
+        },
+        "personImageUrl": {
+          "type": "string",
+          "format": "uri",
+          "title": "Person Image URL",
+          "description": "URL of the person's image"
+        }
       },
       "required": ["personId", "personName", "personRole"]
     },
@@ -83,30 +177,72 @@ export const APP_SCHEMA = {
       "type": "object",
       "title": "Opportunity",
       "properties": {
-        "opportunityId": { "type": "string" },
-        "opportunityName": { "type": "string" },
-        "opportunityDescription": { "type": "string", "format": "textarea" },
-        "opportunityProblem": { "type": "string", "format": "textarea" },
+        "opportunityId": {
+          "type": "string",
+          "title": "Opportunity ID",
+          "description": "Unique identifier for the opportunity"
+        },
+        "opportunityName": {
+          "type": "string",
+          "title": "Opportunity Name",
+          "description": "Name or short title for the opportunity"
+        },
+        "opportunityDescription": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Opportunity Description",
+          "description": "Detailed description of the opportunity"
+        },
+        "opportunityProblem": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Opportunity Problem",
+          "description": "Problem statement or need the opportunity addresses"
+        },
         "opportunitySource": {
           "type": "string",
-          "enum": ["Customer Feedback", "Market Trend", "Internal Brainstorm", "Competitor Analysis", "Technology Scouting", "Employee Idea", "Other"]
+          "enum": ["Customer Feedback", "Market Trend", "Internal Brainstorm", "Competitor Analysis", "Technology Scouting", "Employee Idea", "Other"],
+          "title": "Opportunity Source",
+          "description": "Source of the opportunity"
         },
-        "opportunityStakeholders": { "type": "string", "format": "textarea" },
+        "opportunityStakeholders": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Opportunity Stakeholders",
+          "description": "Stakeholders affected or involved"
+        },
         "opportunityProposerId": {
           "type": "string",
-          "relationshipType": "person"
+          "relationshipType": "person",
+          "title": "Proposer Person ID",
+          "description": "Reference to the person proposing the opportunity"
         },
         "opportunityPriority": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 10
+          "maximum": 10,
+          "title": "Opportunity Priority",
+          "description": "Priority rating from 0 to 10"
         },
         "opportunityStatus": {
           "type": "string",
-          "enum": ["Identified", "Under Review", "Prioritized", "Archived"]
+          "enum": ["Identified", "Under Review", "Prioritized", "Archived"],
+          "title": "Opportunity Status",
+          "description": "Current status of the opportunity"
         },
-        "opportunityDateIdentified": { "type": "string", "format": "date" },
-        "opportunityLastUpdated": { "type": "string", "format": "date-time", "readonly": true }
+        "opportunityDateIdentified": {
+          "type": "string",
+          "format": "date",
+          "title": "Date Identified",
+          "description": "Date when the opportunity was identified"
+        },
+        "opportunityLastUpdated": {
+          "type": "string",
+          "format": "date-time",
+          "readonly": true,
+          "title": "Last Updated",
+          "description": "Timestamp of the last update"
+        }
       },
       "required": [
         "opportunityId",
@@ -122,20 +258,85 @@ export const APP_SCHEMA = {
       "type": "object",
       "title": "iNNitiative",
       "properties": {
-        "iNNitiativeId": { "type": "string" },
-        "iNNitiativeName": { "type": "string" },
-        "iNNitiativeType": { "type": "string" },
-        "iNNitiativePhase": { "type": "string" },
-        "iNNitiativeOwnerPersonId": { "type": "string", "relationshipType": "person" },
-        "iNNitiativeRelatedOpportunityId": { "type": "string", "relationshipType": "opportunity" },
-        "iNNitiativeGoals": { "type": "string", "format": "textarea" },
-        "iNNitiativeValueProposition": { "type": "string", "format": "textarea" },
-        "iNNitiativeExpectedBenefits": { "type": "string", "format": "textarea" },
-        "iNNitiativeRisks": { "type": "string", "format": "textarea" },
-        "iNNitiativeValidation": { "type": "string", "format": "textarea" },
-        "iNNitiativeNotes": { "type": "string", "format": "textarea" },
-        "iNNitiativeStatus": { "type": "string" },
-        "iNNitiativeDateRegistered": { "type": "string", "format": "date" }
+        "iNNitiativeId": {
+          "type": "string",
+          "title": "Initiative ID",
+          "description": "Unique identifier for the initiative"
+        },
+        "iNNitiativeName": {
+          "type": "string",
+          "title": "Initiative Name",
+          "description": "Name of the initiative"
+        },
+        "iNNitiativeType": {
+          "type": "string",
+          "title": "Initiative Type",
+          "description": "Type category of the initiative"
+        },
+        "iNNitiativePhase": {
+          "type": "string",
+          "title": "Initiative Phase",
+          "description": "Current phase of the initiative"
+        },
+        "iNNitiativeOwnerPersonId": {
+          "type": "string",
+          "relationshipType": "person",
+          "title": "Owner Person ID",
+          "description": "Reference to the initiative owner"
+        },
+        "iNNitiativeRelatedOpportunityId": {
+          "type": "string",
+          "relationshipType": "opportunity",
+          "title": "Related Opportunity ID",
+          "description": "Reference to the related opportunity"
+        },
+        "iNNitiativeGoals": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Initiative Goals",
+          "description": "Goals of the initiative"
+        },
+        "iNNitiativeValueProposition": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Value Proposition",
+          "description": "Value proposition of the initiative"
+        },
+        "iNNitiativeExpectedBenefits": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Expected Benefits",
+          "description": "Expected benefits of the initiative"
+        },
+        "iNNitiativeRisks": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Initiative Risks",
+          "description": "Risks associated with the initiative"
+        },
+        "iNNitiativeValidation": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Initiative Validation",
+          "description": "Validation efforts or results"
+        },
+        "iNNitiativeNotes": {
+          "type": "string",
+          "format": "textarea",
+          "title": "Initiative Notes",
+          "description": "Additional notes"
+        },
+        "iNNitiativeStatus": {
+          "type": "string",
+          "title": "Initiative Status",
+          "description": "Current status of the initiative"
+        },
+        "iNNitiativeDateRegistered": {
+          "type": "string",
+          "format": "date",
+          "title": "Date Registered",
+          "description": "Date when the initiative was registered"
+        }
       },
       "required": [
         "iNNitiativeId",


### PR DESCRIPTION
## Summary
- enrich `appSchema.js` with title and description metadata for all fields

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68415f893b208320a1d30111e940cebc