### PR TITLE
Fix Dashboard initiative phases prop name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -72,7 +72,7 @@
             <dashboard-view v-if="activeTab === 'dashboard'"
                 :app-data="appData"
                 :is-empty-data="isEmptyData"
-                :initiative-phases-summary="iNNitiativePhasesSummaryForDashboard"
+                :i-n-nitiative-phases-summary="iNNitiativePhasesSummaryForDashboard"
                 :kanban-phases="kanbanPhases"
                 :initiatives-by-phase="initiativesByPhase"
                 :top-opportunities="topOpportunities"

--- a/public/js/components/DashboardView.js
+++ b/public/js/components/DashboardView.js
@@ -64,7 +64,7 @@ export const DashboardView = {
 
                 <!-- Overview Sections -->
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                    <initiatives-by-phase-summary :initiative-phases-summary="iNNitiativePhasesSummary"></initiatives-by-phase-summary>
+                    <initiatives-by-phase-summary :i-n-nitiative-phases-summary="iNNitiativePhasesSummary"></initiatives-by-phase-summary>
                     <top-opportunities-summary :top-opportunities="topOpportunities" :get-person-name-fn="getPersonNameFn"></top-opportunities-summary>
                 </div>
 


### PR DESCRIPTION
## Summary
- fix the kebab-case attribute for `iNNitiativePhasesSummary` in `index.html`
- update `DashboardView` template to use the same attribute when passing the prop to `InitiativesByPhaseSummary`

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68415fba67ac832090bdbb4356c26017