### PR TITLE
Enhance dashboard and cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,9 @@
     </div>
     <!-- Video -->
     <div class="lg:w-1/2 flex justify-center">
-      <iframe width="560" height="377" src="https://www.youtube.com/embed/3YZm-uzrXxk?si=GtkrbCOa9L2EZ6Yl" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="video-container">
+        <iframe src="https://www.youtube.com/embed/3YZm-uzrXxk?si=GtkrbCOa9L2EZ6Yl" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
     </div>
   </div>
 </section>

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -239,3 +239,16 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
 }
+
+/* Responsive video container */
+.video-container {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+}
+.video-container iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,7 @@
                 :initiatives-by-phase="initiativesByPhase"
                 :top-opportunities="topOpportunities"
                 :recent-initiatives="recentInitiatives"
+                :summary-cards="summaryCards"
                 :get-person-name-fn="getPersonName"
                 :get-person-avatar-fn="getPersonAvatar"
                 :get-person-initiative-count-fn="getPersonInitiativeCount"

--- a/public/js/components/AiModal.js
+++ b/public/js/components/AiModal.js
@@ -44,18 +44,5 @@ export const AiModal = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/DashboardView.js
+++ b/public/js/components/DashboardView.js
@@ -4,6 +4,7 @@ export const DashboardView = {
         isEmptyData: Boolean,
         iNNitiativePhasesSummary: Array, // Renamed from iNNitiativePhases in main app
         kanbanPhases: Array,
+        summaryCards: Array,
         initiativesByPhase: Object,
         topOpportunities: Array,
         recentInitiatives: Array,
@@ -42,9 +43,10 @@ export const DashboardView = {
             <div v-else class="space-y-8">
                 <!-- Stats Cards -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    <stats-card title="Team Members" :value="appData.people.length" icon="users" color-theme="green" target-tab="people" @card-clicked="$emit('set-active-tab', $event)"></stats-card>
-                    <stats-card title="Opportunities" :value="appData.opportunities.length" icon="lightbulb" color-theme="yellow" target-tab="opportunities" @card-clicked="$emit('set-active-tab', $event)"></stats-card>
-                    <stats-card title="Active Initiatives" :value="appData.initiatives.length" icon="zap" color-theme="purple" target-tab="initiatives" @card-clicked="$emit('set-active-tab', $event)"></stats-card>
+                    <stats-card v-for="card in summaryCards" :key="card.title"
+                        :title="card.title" :value="card.value" :icon="card.icon"
+                        :color-theme="card.colorTheme" :target-tab="card.targetTab"
+                        @card-clicked="$emit('set-active-tab', $event)"></stats-card>
                 </div>
 
                 <!-- Kanban Board Section -->
@@ -73,19 +75,5 @@ export const DashboardView = {
             </div>
         </section>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        // This is important to re-render icons if data changes and v-if/v-for blocks are affected
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/DataControls.js
+++ b/public/js/components/DataControls.js
@@ -28,20 +28,5 @@ export const DataControls = {
             this.$emit('export-data-requested');
         }
     },
-    mounted() {
-        // Ensure icons are rendered when the component mounts
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        // Ensure icons are rendered when the component updates (e.g. if template changes)
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/FieldRenderer.js
+++ b/public/js/components/FieldRenderer.js
@@ -81,10 +81,5 @@ export const FieldRenderer = {
       </template>
     </div>
   `,
-  mounted() {
-    this.$nextTick(() => { if (typeof lucide !== 'undefined') { lucide.createIcons(); } });
-  },
-  updated() {
-    this.$nextTick(() => { if (typeof lucide !== 'undefined') { lucide.createIcons(); } });
-  }
+
 };

--- a/public/js/components/HelpModal.js
+++ b/public/js/components/HelpModal.js
@@ -23,19 +23,5 @@ export const HelpModal = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        // If contentHtml changes, icons might need to be re-rendered if they are part of the HTML
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/InitiativesByPhaseSummary.js
+++ b/public/js/components/InitiativesByPhaseSummary.js
@@ -24,18 +24,5 @@ export const InitiativesByPhaseSummary = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/ItemBadge.js
+++ b/public/js/components/ItemBadge.js
@@ -41,18 +41,5 @@ export const ItemBadge = {
             <span>{{ name }}</span>
         </span>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/ItemCard.js
+++ b/public/js/components/ItemCard.js
@@ -18,6 +18,15 @@ export const ItemCard = {
             }
             return null;
         },
+        descriptionSnippet() {
+            if (this.type === 'opportunity' && this.item.opportunityDescription) {
+                return this.item.opportunityDescription.substring(0, 80);
+            }
+            if (this.type === 'initiative' && this.item.iNNitiativeGoals) {
+                return this.item.iNNitiativeGoals.substring(0, 80);
+            }
+            return '';
+        },
         badges() {
             const b = [];
             if (this.type === 'opportunity') {
@@ -63,6 +72,13 @@ export const ItemCard = {
                         type: 'opportunity'
                     });
                 }
+                if (this.item.iNNitiativePhase) {
+                    b.push({
+                        kind: 'text',
+                        value: this.item.iNNitiativePhase,
+                        icon: 'flag'
+                    });
+                }
             }
             return b;
         }
@@ -73,6 +89,7 @@ export const ItemCard = {
                 <img v-if="avatar" :src="avatar" class="w-12 h-12 rounded-full object-cover border"/>
                 <div class="min-w-0">
                     <h3 class="text-lg font-semibold text-blue-700 truncate" :title="itemName">{{ itemName }}</h3>
+                    <p v-if="descriptionSnippet" class="text-sm text-gray-600 truncate">{{ descriptionSnippet }}</p>
                     <div v-if="badges.length" class="flex flex-wrap gap-1 mt-1">
                         <template v-for="(badge, idx) in badges" :key="idx">
                             <item-badge

--- a/public/js/components/KanbanColumn.js
+++ b/public/js/components/KanbanColumn.js
@@ -32,18 +32,5 @@ export const KanbanColumn = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/ProgramView.js
+++ b/public/js/components/ProgramView.js
@@ -55,18 +55,5 @@ export const ProgramView = {
             </div>
         </section>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/RecentActivitySummary.js
+++ b/public/js/components/RecentActivitySummary.js
@@ -27,18 +27,5 @@ export const RecentActivitySummary = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/StatsCard.js
+++ b/public/js/components/StatsCard.js
@@ -35,18 +35,5 @@ export const StatsCard = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/TabNavigation.js
+++ b/public/js/components/TabNavigation.js
@@ -37,20 +37,5 @@ export const TabNavigation = {
             this.$emit('update:activeTab', tabId);
         }
     },
-    mounted() {
-        // Ensure icons are rendered when the component mounts
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        // Ensure icons are rendered when the component updates
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/components/TableView.js
+++ b/public/js/components/TableView.js
@@ -103,10 +103,5 @@ export const TableView = {
         </div>
     `
     ,
-    mounted() {
-        this.$nextTick(() => { if (typeof lucide !== 'undefined') lucide.createIcons(); });
-    },
-    updated() {
-        this.$nextTick(() => { if (typeof lucide !== 'undefined') lucide.createIcons(); });
-    }
+
 };

--- a/public/js/components/TeamOverviewSummary.js
+++ b/public/js/components/TeamOverviewSummary.js
@@ -27,18 +27,5 @@ export const TeamOverviewSummary = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+    
 };

--- a/public/js/components/TopOpportunitiesSummary.js
+++ b/public/js/components/TopOpportunitiesSummary.js
@@ -29,18 +29,5 @@ export const TopOpportunitiesSummary = {
             </div>
         </div>
     `,
-    mounted() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    },
-    updated() {
-        this.$nextTick(() => {
-            if (typeof lucide !== 'undefined') {
-                lucide.createIcons();
-            }
-        });
-    }
+
 };

--- a/public/js/fieldMeta.js
+++ b/public/js/fieldMeta.js
@@ -11,8 +11,6 @@ export const FIELD_ICONS = {
   iNNitiativeName: 'activity',
   iNNitiativePhase: 'flag',
   iNNitiativeType: 'tag',
-  programSponsorPersonId: 'user',
-  programManagerPersonId: 'user',
   iNNitiativeOwnerPersonId: 'user',
   iNNitiativeRelatedOpportunityId: 'lightbulb'
 };


### PR DESCRIPTION
## Summary
- remove duplicate icon mappings
- rely on global lucide mixin and drop per-component hooks
- reformat form helpers in `app.js`
- show extra info in item cards
- build dashboard cards dynamically
- embed responsive video on marketing page

## Testing
- `node --check public/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68416b6d2c988320a77c0376aa23a029