### PR TITLE
Add AI Assistant button

### DIFF
--- a/public/js/components/AiModal.js
+++ b/public/js/components/AiModal.js
@@ -1,3 +1,5 @@
+import { APP_CONFIG } from '../config.js';
+
 export const AiModal = {
     props: {
         show: Boolean,
@@ -9,6 +11,11 @@ export const AiModal = {
     methods: {
         closeModal() {
             this.$emit('close-modal-requested');
+        },
+        copyPromptAndOpenAssistant() {
+            navigator.clipboard.writeText(this.fullPrompt).catch(() => {}).finally(() => {
+                window.open(APP_CONFIG.assistantUrl, '_blank');
+            });
         }
     },
     template: `
@@ -35,10 +42,10 @@ export const AiModal = {
                             <div v-html="contextQuestionsHtml" class="bg-gray-50 p-2.5 rounded-md max-h-60 overflow-y-auto border border-gray-200 text-xs prose prose-sm"></div>
                         </div>
                     </div>
-                    <div class="flex flex-col sm:flex-row justify-around items-center pt-4 border-t mt-4 space-y-2 sm:space-y-0 sm:space-x-3">
-                        <a href="https://chat.openai.com" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">ChatGPT</a>
-                        <a href="https://gemini.google.com" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">Gemini</a>
-                        <a href="https://claude.ai" target="_blank" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">Claude</a>
+                    <div class="flex flex-col sm:flex-row justify-center items-center pt-4 border-t mt-4">
+                        <button @click="copyPromptAndOpenAssistant" class="text-blue-600 hover:text-blue-700 font-semibold text-sm">
+                            Copiar en inglés, copiar prompt y abrir AI Assistant
+                        </button>
                     </div>
                 </div>
             </div>

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,0 +1,3 @@
+export const APP_CONFIG = {
+    assistantUrl: 'https://chatgpt.com/g/g-684095506b1c81919da40a1ad5ee65a8-innitiatives-bot'
+};


### PR DESCRIPTION
## Summary
- simplify AI modal buttons
- allow customizing assistant URL via `APP_CONFIG`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68418daa36ec832095e96981bc9b1373