### PR TITLE
Add process guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive Vue.js application for managing innovation programs, opportuniti
 - **Opportunities Tracking**: Identify and track innovation opportunities
 - **Initiative Management**: Manage innovation initiatives with detailed tracking
 - **Data Export/Import**: JSON-based data management with timestamped exports
+- **Process Guide**: Detailed workflow documentation accessible via Docsify
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
       <p class="italic text-gray-600">Start innovating today—with confidence.</p>
       <div class="mt-8 space-x-4">
         <a href="#" class="inline-block px-6 py-2 bg-black text-white rounded hover:bg-gray-800">Request a Demo</a>
-        <a href="#" class="inline-block px-6 py-2 border border-black rounded hover:bg-gray-200">Download the Process Guide</a>
+        <a href="https://docsify-this.net/?basePath=https://innv0.github.io/iNNitiatives/public&homepage=iNNitiatives.struml.md&sidebar=true#/" class="inline-block px-6 py-2 border border-black rounded hover:bg-gray-200">Download the Process Guide</a>
       </div>
     </div>
   </section>

--- a/public/js/components/TabNavigation.js
+++ b/public/js/components/TabNavigation.js
@@ -28,6 +28,10 @@ export const TabNavigation = {
                         <i data-lucide="book" class="w-4 h-4"></i>
                         <span>Docs</span>
                     </a>
+                    <a href="https://docsify-this.net/?basePath=https://innv0.github.io/iNNitiatives/public&homepage=iNNitiatives.struml.md&sidebar=true#/" target="_blank" class="flex items-center space-x-2 px-4 py-3 text-sm font-medium rounded-t-lg transition-colors whitespace-nowrap text-gray-600 hover:text-gray-900 hover:bg-gray-50">
+                        <i data-lucide="list" class="w-4 h-4"></i>
+                        <span>Process</span>
+                    </a>
                 </div>
             </div>
         </nav>

--- a/public/prompt.md
+++ b/public/prompt.md
@@ -32,9 +32,13 @@ Based on the provided JSON model and its content identify the language used and 
 
 ---
 
-📄 **Docs**  
+📄 **Docs**
 If the user chooses option 8, provide this link to access live documentation:
 🔗 https://docsify-this.net/?basePath=https://innv0.github.io/iNNitiatives/public&homepage=docs.md&sidebar=true#/
+
+📄 **Process Guide**
+Use this link to explore the full process guide rendered with Docsify:
+🔗 https://docsify-this.net/?basePath=https://innv0.github.io/iNNitiatives/public&homepage=iNNitiatives.struml.md&sidebar=true#/
 
 ---
 


### PR DESCRIPTION
## Summary
- add Process Guide entry in features
- link Process Guide on marketing page
- expose Process Guide via navigation bar and AI prompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c6dfcc508320b731e11e6b2cdab3